### PR TITLE
Make dotconf_create fname const char *

### DIFF
--- a/src/dotconf.c
+++ b/src/dotconf.c
@@ -768,7 +768,7 @@ void dotconf_cleanup(configfile_t * configfile)
 	free(configfile);
 }
 
-configfile_t *dotconf_create(char *fname, const configoption_t * options,
+configfile_t *dotconf_create(const char *fname, const configoption_t * options,
 			     context_t * context, unsigned long flags)
 {
 	char *dc_env = NULL;
@@ -1423,7 +1423,7 @@ char *get_cwd(void)
 	return buf;
 }
 
-char *get_path(char *name)
+char *get_path(const char *name)
 {
 	char *tmp;
 	char *buf = NULL;

--- a/src/dotconf.h
+++ b/src/dotconf.h
@@ -176,7 +176,7 @@ extern "C" {
 	};
 
 /* ------ dotconf_create() - create the configfile_t needed for further dot.conf fun ------------ */
-	configfile_t *dotconf_create(char *, const configoption_t *,
+	configfile_t *dotconf_create(const char *, const configoption_t *,
 				     context_t *, unsigned long);
 
 /* ------ dotconf_cleanup() - tidy up behind dotconf_create and the parser dust ----------------- */

--- a/src/dotconf_priv.h
+++ b/src/dotconf_priv.h
@@ -37,6 +37,6 @@
 
 char *get_cwd(void);
 
-char *get_path(char *name);
+char *get_path(const char *name);
 
 #endif


### PR DESCRIPTION
Since it does not modify it, and callers might be using a const string.